### PR TITLE
VAN-1333 Remove OWNER perms from GCS bucket

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -40,7 +40,7 @@ resource "google_storage_bucket" "website_bucket" {
 resource "google_storage_bucket_acl" "website_bucket_acl" {
   provider    = google-beta
   bucket      = google_storage_bucket.website_bucket.name
-  role_entity = ["READER:allUsers", "OWNER:allAuthenticatedUsers"]
+  role_entity = ["READER:allUsers"]
 }
 
 resource "google_storage_default_object_access_control" "public_rule" {


### PR DESCRIPTION
The bucket created by the TF code shouldn't have allAuthenticatedUsers
as OWNER. This has been removed.
